### PR TITLE
fix: HTTPs with PEM & get COOKIEs on frontend finally

### DIFF
--- a/Controller/user.js
+++ b/Controller/user.js
@@ -4,19 +4,20 @@ const hashPassword = require('../utils/authorization').hashPassword;
 require('dotenv').config('../.env');
 async function signup(req, res) {
 
-    if (!req.body.email || !req.body.password || !req.body.name || !req.body.age
-      || !req.body.gender || !req.body.self_intro) {
-        return res.status(400).send('Missing value');
-    }
-
-    if (!req.body.email.match(/^[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[A-Za-z]+$/)) {
-        return res.status(400).send('Invalid email format');
-    }
-
+    // Move E-mail check first due to frontend validation progress
     const user = await model.getUser('email', req.body.email);
 
     if (user) {
         return res.status(400).send('Email already exists');
+    }
+    
+    if (!req.body.email.match(/^[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[A-Za-z]+$/)) {
+        return res.status(400).send('Invalid email format');
+    }
+
+    if (!req.body.email || !req.body.password || !req.body.name || !req.body.age
+      || !req.body.gender || !req.body.self_intro ) {
+        return res.status(400).send('Missing value');
     }
 
 

--- a/Route/app.js
+++ b/Route/app.js
@@ -11,12 +11,11 @@ const app = express();
 const { Session } = require('../utils/session');
 require('dotenv').config('../.env');
 
-
-
 const corsOptions = {
-    //all origin for now
-    origin: '*',
-    optionsSuccessStatus: 200 // some legacy browsers (IE11, various SmartTVs) choke on 204
+    // allow localhost only for test
+    origin: ["http://localhost:5173", "http://192.168.0.55:5173"],
+    optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
+    credentials: true
 }
 
 app.use(cors(corsOptions));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,19 @@
 const { app } = require('./Route/app');
 require('dotenv').config();
 
-app.listen(3000, () => {
+// These are required for running HTTPs and use certificates
+const https = require('https');
+const fs = require('fs');
+
+const options = {
+    key: fs.readFileSync('/Users/cdxvy30/example.com+5-key.pem'),
+    cert: fs.readFileSync('/Users/cdxvy30/example.com+5.pem'),
+  };
+
+https.createServer(options, app).listen(3000, () => {
     console.log('Server is running on port 3000');
 });
+
+// app.listen(3000, () => {
+//     console.log('Server is running on port 3000');
+// });

--- a/utils/session.js
+++ b/utils/session.js
@@ -17,7 +17,7 @@ const Session = session({
     resave: false,
     saveUninitialized: false,
     cookie: {
-      secure: false,
+      secure: true,
       httpOnly: true,
       sameSite: 'none',
       maxAge: 60 * 60 * 24 * 1000


### PR DESCRIPTION
1. 在 local 端用 mkcert 工具 gen 出兩個 PEM file，用作本地端 HTTPs server 的開發
2. 調整 CORS 相關設定，讓前端可以成功 get cookie